### PR TITLE
Refactor: Enhance spreadsheet encoding with data types and categories

### DIFF
--- a/Spreadsheet_LLM_Encoder.py
+++ b/Spreadsheet_LLM_Encoder.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd  # Used for some data manipulation
 import openpyxl
 import json
+from temp_helpers import infer_cell_data_type, categorize_number_format
 from collections import defaultdict
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.cell import coordinate_from_string
@@ -161,8 +162,15 @@ def get_cell_format_key(cell):
         else:
             format_info["fill"] = {"color": None}
 
-        # 5. Number Format
-        format_info["number_format"] = cell.number_format
+        # 5. Number Format (Original, Inferred Type, Category)
+        original_number_format = cell.number_format
+        inferred_type = infer_cell_data_type(cell) # Call new helper
+        category = categorize_number_format(original_number_format, inferred_type) # Call new helper
+
+        format_info["original_number_format"] = original_number_format
+        format_info["inferred_data_type"] = inferred_type
+        format_info["number_format_category"] = category
+        # format_info["number_format"] = cell.number_format # Keep original for now, or decide if it's redundant
     except Exception as e:
         # If there's an error extracting format, use a simplified format key
         format_info = {"error": str(e)}
@@ -261,8 +269,15 @@ def create_inverted_index(sheet, kept_rows, kept_cols):
                 else:
                     format_info["fill"] = {"color": None}
 
-                # 5. Number Format
-                format_info["number_format"] = cell.number_format
+                # 5. Number Format (Original, Inferred Type, Category)
+                original_number_format = cell.number_format
+                inferred_type = infer_cell_data_type(cell) # Call new helper
+                category = categorize_number_format(original_number_format, inferred_type) # Call new helper
+
+                format_info["original_number_format"] = original_number_format
+                format_info["inferred_data_type"] = inferred_type
+                format_info["number_format_category"] = category
+                # format_info["number_format"] = cell.number_format # Redundant
 
                 # Store the format (handle merged ranges specially in format key)
                 if merged_range is not None:

--- a/temp_helpers.py
+++ b/temp_helpers.py
@@ -1,0 +1,125 @@
+import openpyxl # Required for type hinting Cell
+
+# --- Helper Functions for Format Information Extraction (Step 1) ---
+def infer_cell_data_type(cell: openpyxl.cell.cell.Cell) -> str:
+    """
+    Infers the data type of a cell based on its openpyxl data_type and value.
+    """
+    if cell.value is None:
+        return "empty"
+
+    data_type = cell.data_type
+    if data_type == 's': # Standard string
+        return "text"
+    elif data_type == 'n': # Number
+        return "numeric"
+    elif data_type == 'b': # Boolean
+        return "boolean"
+    elif data_type == 'd': # Datetime
+        return "datetime"
+    elif data_type == 'e': # Error
+        return "error"
+    elif data_type == 'f': # Formula
+        if cell.value is not None: # openpyxl might store the last calculated value
+            if isinstance(cell.value, str):
+                return "text"
+            elif isinstance(cell.value, (int, float)):
+                return "numeric"
+            elif isinstance(cell.value, bool):
+                return "boolean"
+            # Dates from formulas could be datetime objects (type 'd') or numbers formatted as dates (type 'n').
+            # This function primarily uses cell.data_type, so 'd' is handled. 'n' will be "numeric".
+            else:
+                return "formula_cached_value" # Other cached types
+        return "formula" # No cached value or type not easily inferred
+    elif data_type == 'g': # General (often for empty or untyped cells)
+        # Already checked for cell.value is None. If 'g' and not None, treat as text.
+        if cell.value is not None:
+            return "text"
+        else:
+            return "empty" # Fallback, though None check should catch this.
+    else: # Includes 'is' (inlineStr), 'str' (formula string, rare for type)
+        return "unknown"
+
+def categorize_number_format(number_format_string: str, cell_data_type: str) -> str:
+    """
+    Categorizes the number format of a cell.
+    """
+    if cell_data_type not in ["numeric", "datetime"]:
+        return "not_applicable"
+
+    if number_format_string is None or number_format_string.lower() == "general":
+        if cell_data_type == "datetime":
+            # If openpyxl identified it as datetime but format is general, it's a date.
+            return "datetime_general"
+        return "general" # General numeric
+
+    # Text format override (Format Code: @)
+    if number_format_string == "@" or number_format_string.lower() == "text":
+        return "text_format"
+
+    # Currency symbols (common ones)
+    if any(c in number_format_string for c in ['$', '€', '£', '¥']):
+        return "currency"
+
+    # Percentage symbol
+    if '%' in number_format_string:
+        return "percentage"
+
+    # Scientific notation (e.g., 1.23E+05)
+    if 'E+' in number_format_string or 'E-' in number_format_string.upper(): # Openpyxl stores 'E+' or 'e+'
+        return "scientific"
+
+    # Fraction (e.g., # ?/?)
+    if '#' in number_format_string and '/' in number_format_string and '?' in number_format_string:
+        return "fraction"
+
+    # Date/Time related checks
+    # These patterns are indicative and might need refinement for complex/custom Excel formats.
+    is_date_format = False
+    is_time_format = False
+
+    # Common date components (lowercase for matching)
+    nf_lower = number_format_string.lower()
+    date_keywords = ['yyyy', 'yy', 'mmmm', 'mmm', 'mm', 'dddd', 'ddd', 'dd', 'd']
+    if any(keyword in nf_lower for keyword in date_keywords):
+        is_date_format = True
+
+    # Common time components (lowercase for matching)
+    time_keywords = ['hh', 'h', 'ss', 's', 'am/pm', 'a/p']
+    if any(keyword in nf_lower for keyword in time_keywords):
+        is_time_format = True
+
+    # Presence of colons, not part of a numeric placeholder like 0.00 or #,##0.00
+    if ':' in number_format_string:
+        # Avoid misclassifying "0.00" or "#,##0.00" if they contain ':' somehow (unlikely in valid formats)
+        # A simple check: if there are digits around colons, it's more likely time.
+        # More robustly, check if it's not purely a number format with colons.
+        temp_nf = number_format_string.replace('0','').replace('#','').replace(',','').replace('.','')
+        if ':' in temp_nf: # If colon persists after removing numeric placeholders
+            is_time_format = True
+
+
+    if is_date_format and is_time_format:
+        return "datetime_custom" # Contains both date and time elements
+    elif is_date_format:
+        if 'yyyy' in nf_lower or 'mmmm' in nf_lower or 'dddd' in nf_lower:
+            return "date_long" # Longer date formats
+        elif 'yy' in nf_lower or 'mmm' in nf_lower or 'ddd' in nf_lower:
+            return "date_short" # Shorter date formats
+        return "other_date" # Other formats that look like dates
+    elif is_time_format:
+        return "time_custom" # Formats that look like times
+
+    # Fallback for numeric types if no other category matched yet
+    if cell_data_type == "numeric":
+        # Check for common explicit numeric formats that aren't "General"
+        if number_format_string in ["0", "#,##0", "0.00", "#,##0.00", "0.0", "#,##0.0"]:
+            return "general_numeric_explicit"
+        return "other_numeric" # Numeric, but not currency, percentage, scientific, fraction, or common general.
+
+    # If cell_data_type was 'datetime' but format string didn't trigger specific date/time patterns
+    if cell_data_type == "datetime":
+        return "other_date" # It's a date type, but format is unusual (e.g. a custom number format applied to a date)
+
+    return "unknown_format_category" # Default if no category fits


### PR DESCRIPTION
I've incorporated insights from the "State of the Art in LLM-Spreadsheet Interaction" report to improve the SpreadsheetLLM encoder.

Key changes I made:
- I added helper functions to infer cell data types (e.g., numeric, text, date, boolean) and categorize Excel number formats (e.g., currency, percentage, date_short). These are stored in `temp_helpers.py`.
- I modified `get_cell_format_key` and the format extraction logic within `create_inverted_index` to include these inferred data types and number format categories within the generated format keys. The original number format string is also preserved.
- This results in a richer, more semantically detailed representation of cell formats in the output JSON, under the `formats` field. The keys of this dictionary now embed this enhanced type and category information.

Benefits for you:
- This aligns the encoder more closely with concepts like "native understanding" and "data-format-aware aggregation" discussed in the report.
- It provides a more informative JSON output that can better enable LLMs to understand the structure and semantics of spreadsheet data, particularly for numerical and date-based content.
- The `aggregate_formats` function now implicitly benefits by operating on these more descriptive format keys, leading to more semantically relevant aggregation of cell regions.

A minor planned refinement to `aggregate_formats` (dynamic aggregation threshold) was not implemented, but the primary
enhancements to format representation are in place.