### PR TITLE
Replace print statements with logging

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,10 +2,14 @@ import streamlit as st
 import pandas as pd
 import json
 import base64
+import logging
 from Spreadsheet_LLM_Encoder import spreadsheet_llm_encode
 import openpyxl
 import tempfile
 import os
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.cell import coordinate_from_string, column_index_from_string # For parsing cell/range refs
 import re # For parsing number format strings
@@ -369,7 +373,9 @@ def analyze_sheet_for_compression_insights(sheet_json_data):
                     base_format_groups[base_format_key_tuple] = []
                 base_format_groups[base_format_key_tuple].append(fmt_details.get("number_format", "General"))
             except json.JSONDecodeError:
-                print(f"Warning (compression_insights): Malformed format key string found: {fmt_key_str}")
+                logger.warning(
+                    f"Warning (compression_insights): Malformed format key string found: {fmt_key_str}"
+                )
                 continue
 
         for base_fmt_tuple, number_format_list in base_format_groups.items():


### PR DESCRIPTION
## Summary
- switch to logger in Spreadsheet_LLM_Encoder
- add logging setup to command-line entry
- initialize logging in streamlit_app and log warning for malformed keys

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847934f76288329a9862bd459f3b149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced print statements with structured logging for informational and warning messages.
  - Improved error and process reporting by adopting Python’s logging framework for user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->