### PR TITLE
Add pyproject with CLI entry

### DIFF
--- a/Spreadsheet_LLM_Encoder.py
+++ b/Spreadsheet_LLM_Encoder.py
@@ -397,17 +397,33 @@ def split_cell_ref(cell_ref):
     # convert row to integer
     return col_str, int(row_str)
 
-if __name__ == "__main__":
+def main():
+    """Console script entry point for SpreadsheetLLM encoder."""
     import argparse
 
-    parser = argparse.ArgumentParser(description='Convert Excel files to SpreadsheetLLM format')
-    parser.add_argument('excel_file', help='Path to the Excel file')
-    parser.add_argument('--output', '-o', help='Output JSON file path (default: same as input with .json extension)')
-    parser.add_argument('--k', type=int, default=2, help='Neighborhood distance parameter (default: 2)')
+    parser = argparse.ArgumentParser(
+        description="Convert Excel files to SpreadsheetLLM format"
+    )
+    parser.add_argument("excel_file", help="Path to the Excel file")
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output JSON file path (default: same as input with .json extension)",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=2,
+        help="Neighborhood distance parameter (default: 2)",
+    )
 
     args = parser.parse_args()
 
     if not args.output:
-        args.output = os.path.splitext(args.excel_file)[0] + '_spreadsheetllm.json'
+        args.output = os.path.splitext(args.excel_file)[0] + "_spreadsheetllm.json"
 
     spreadsheet_llm_encode(args.excel_file, args.output, args.k)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spreadsheet-llm-encoder"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "openpyxl",
+    "pandas",
+    "streamlit"
+]
+
+[project.scripts]
+spreadsheet-llm-encode = "Spreadsheet_LLM_Encoder:main"
+
+[tool.setuptools]
+py-modules = ["Spreadsheet_LLM_Encoder", "streamlit_app", "temp_helpers"]


### PR DESCRIPTION
## Summary
- add pyproject metadata for packaging
- expose a console script entry point `spreadsheet-llm-encode`
- refactor `Spreadsheet_LLM_Encoder.py` to provide a `main` function

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68479352313c8329b3b8d01014596853