### PR TITLE
Implement compression stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ Instead of storing each cell individually, the encoder creates an inverted index
 
 Cell formats are aggregated into rectangular regions where possible, maintaining visual formatting information while minimizing duplication.
 
-### 5. JSON Encoding
+### 5. Compression
+
+Heterogeneous rows and columns around anchors are retained while uniform regions are skipped. Numeric cells with identical formatting are clustered into aggregated ranges.
+
+### 6. JSON Encoding
 
 The final output is a structured JSON document containing:
 - File metadata
@@ -92,6 +96,7 @@ The final output is a structured JSON document containing:
 - Structural anchors
 - Cell values (inverted index)
 - Format regions
+- Numeric ranges
 
 ## Output Format
 
@@ -113,6 +118,9 @@ The encoder produces a JSON with this structure:
       },
       "formats": {
         "{format_definition}": ["A1:C1", "A10:F10"]
+      },
+      "numeric_ranges": {
+        "{format_definition}": ["B2:B8"]
       }
     }
   }

--- a/test_encoder_compression.py
+++ b/test_encoder_compression.py
@@ -1,0 +1,46 @@
+import openpyxl
+from Spreadsheet_LLM_Encoder import spreadsheet_llm_encode
+
+
+def create_workbook_numeric_region(path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    # Heterogeneous first row
+    for c, val in enumerate([1, 2, 3, 4], start=1):
+        ws.cell(row=1, column=c, value=val).number_format = '0'
+    # Homogeneous numeric block below
+    for r in range(2,5):
+        for c in range(1,5):
+            ws.cell(row=r, column=c, value=0).number_format = '0'
+    wb.save(path)
+
+
+def create_workbook_with_homogeneous_rows(path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws['A1'] = 'ID'
+    ws['B1'] = 'Value'
+    for r in [2,3]:
+        ws.cell(row=r, column=1, value=0)
+        ws.cell(row=r, column=2, value=0)
+    ws['A4'] = 'End'
+    ws['B4'] = 5
+    wb.save(path)
+
+
+def test_numeric_range_aggregation(tmp_path):
+    file_path = tmp_path / "num.xlsx"
+    create_workbook_numeric_region(str(file_path))
+    result = spreadsheet_llm_encode(str(file_path))
+    ranges = result['sheets']['Sheet']['numeric_ranges']
+    any_large = any(any(':' in r and r != r.split(':')[0] for r in rs) for rs in ranges.values())
+    assert any_large, "Numeric ranges were not aggregated"
+
+
+def test_homogeneous_rows_skipped(tmp_path):
+    file_path = tmp_path / "homog.xlsx"
+    create_workbook_with_homogeneous_rows(str(file_path))
+    result = spreadsheet_llm_encode(str(file_path), k=1)
+    cells = result['sheets']['Sheet']['cells']
+    refs = [ref for lst in cells.values() for ref in lst]
+    assert not any(ref.endswith('2') or ref.endswith('3') for ref in refs)


### PR DESCRIPTION
## Summary
- compress homogeneous rows/columns before indexing
- cluster numeric cells into aggregated ranges
- document compression and numeric range output
- add tests covering numeric range aggregation and homogeneous row skipping

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684794ab5ad48329af53a6ab250c6475