### PR TITLE
Support merged range inverted index

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Using the identified anchors, the encoder extracts cells within a configurable d
 
 ### 3. Inverted Index Creation
 
-Instead of storing each cell individually, the encoder creates an inverted index mapping content values to cell references. This significantly reduces redundancy and creates a more compact representation.
+Instead of storing each cell individually, the encoder creates an inverted index mapping content values to cell references. Identical values are merged into contiguous address ranges and empty cells are omitted, resulting in a compact representation.
 
 ### 4. Format Region Aggregation
 
@@ -90,7 +90,7 @@ The final output is a structured JSON document containing:
 - File metadata
 - Sheet information
 - Structural anchors
-- Cell values (inverted index)
+- Cell values (inverted index with merged ranges)
 - Format regions
 
 ## Output Format
@@ -107,7 +107,7 @@ The encoder produces a JSON with this structure:
         "columns": ["A", "C", "F"]
       },
       "cells": {
-        "Header": ["A1", "B1", "C1"],
+        "Header": ["A1:C1"],
         "42": ["B5"],
         "Total": ["A10"]
       },


### PR DESCRIPTION
## Summary
- add `create_inverted_index_translation` to merge contiguous cell ranges
- integrate merged ranges in `spreadsheet_llm_encode`
- document merged inverted index in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847971bc0d883298a0c32fbbb1d1ab2