### PR TITLE
Add compression ratio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Parameters:
 - `--output`, `-o`: Path to save the JSON output (optional, defaults to input filename with '_spreadsheetllm.json' suffix)
 - `--k`: Neighborhood distance parameter for structural anchors (optional, default=2)
 
+The CLI prints compression ratios for each sheet and overall. These metrics are also stored in the output JSON under `compression_metrics`.
+
 ### Python API
 
 ```python
@@ -114,6 +116,26 @@ The encoder produces a JSON with this structure:
       "formats": {
         "{format_definition}": ["A1:C1", "A10:F10"]
       }
+    }
+  }
+}
+```
+
+### Compression Metrics
+
+The encoder reports token counts before and after each stage. These values are stored under `compression_metrics` in the JSON output. Example:
+
+```json
+"compression_metrics": {
+  "overall": {
+    "overall_ratio": 3.5
+  },
+  "sheets": {
+    "Sheet1": {
+      "anchor_ratio": 2.1,
+      "inverted_index_ratio": 3.0,
+      "format_ratio": 3.4,
+      "overall_ratio": 3.5
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `calculate_compression_ratio` helper
- compute token counts at each encoding stage
- report compression metrics in the CLI and JSON
- document new metrics in README

## Testing
- `python -m py_compile Spreadsheet_LLM_Encoder.py streamlit_app.py temp_helpers.py test_streamlit_app.py`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847971f19308329999bb9f9ca776af7