### PR TITLE
Fix NameError: rename aggregate_formats to aggregate_regions_dfs

### DIFF
--- a/Spreadsheet_LLM_Encoder.py
+++ b/Spreadsheet_LLM_Encoder.py
@@ -721,7 +721,7 @@ def create_inverted_index_translation(inverted_index):
     return merged_index
 
 
-def aggregate_formats(sheet, format_map):
+def aggregate_regions_dfs(sheet, format_map):
     """Aggregate cells with the same inferred type and number format string."""
     aggregated_formats = defaultdict(list)
     processed_cells = set()
@@ -814,7 +814,7 @@ def cluster_numeric_ranges(sheet, format_map):
                         f"{get_column_letter(c)}{r}"
                     )
 
-    return aggregate_formats(sheet, numeric_map)
+    return aggregate_regions_dfs(sheet, numeric_map)
 
 
 def get_column_index(col_letter):


### PR DESCRIPTION
## Summary
Fixes a `NameError` that causes the encoder to crash when processing any Excel file. Renames the `aggregate_formats()` function to `aggregate_regions_dfs()` to match its call sites throughout the codebase.

  ## Problem
  The encoder fails with:
  NameError: name 'aggregate_regions_dfs' is not defined

  The function is called as `aggregate_regions_dfs()` at lines 129 and 140, but is defined as `aggregate_formats()` at line 724, causing a name mismatch.

  ## Changes
  - Renamed `aggregate_formats()` to `aggregate_regions_dfs()` at line 724
  - Updated internal call in `cluster_numeric_ranges()` at line 817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->